### PR TITLE
add a new field category to shoppinglist so users know what category their shopping item falls into

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,23 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="MainActivity (1)">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-03-06T08:42:18.044749Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/evancollege/.android/avd/Pixel_4_API_34.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
-      <SelectionState runConfigName="MainActivity (2)">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="MainActivity (3)">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -24,7 +24,10 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="MainActivity">
+      <SelectionState runConfigName="MainActivity (2)">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="MainActivity (3)">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/app/src/main/java/ie/setu/mad2_assignment_one/data/Converters.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/data/Converters.kt
@@ -5,6 +5,12 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 class Converters {
+    @TypeConverter
+    fun fromCategory(category: Category): String = category.name
+
+    @TypeConverter
+    fun toCategory(categoryName: String): Category = Category.valueOf(categoryName)
+
     // ShoppingItem
     @TypeConverter
     fun fromShoppingItem(shoppingItem: ShoppingItem): String {

--- a/app/src/main/java/ie/setu/mad2_assignment_one/data/InventoryDatabase.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/data/InventoryDatabase.kt
@@ -10,7 +10,7 @@ import ie.setu.mad2_assignment_one.data.dao.ShoppingListItemDao
 import ie.setu.mad2_assignment_one.data.dao.ShoppingListItemListDao
 import ie.setu.mad2_assignment_one.data.dao.StoreDao
 
-@Database(entities = [ShoppingItem::class, ShoppingListItem::class, ShoppingListItemList:: class, Store:: class], version = 1, exportSchema = false)
+@Database(entities = [ShoppingItem::class, ShoppingListItem::class, ShoppingListItemList:: class, Store:: class], version = 2, exportSchema = false)
 @TypeConverters(Converters::class)
 abstract class InventoryDatabase: RoomDatabase() {
     abstract fun shoppingItemDao(): ShoppingItemDao

--- a/app/src/main/java/ie/setu/mad2_assignment_one/data/ShoppingItem.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/data/ShoppingItem.kt
@@ -9,6 +9,14 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
 
+// enum Categories
+enum class Category {
+    GROCERIES,
+    ELECTRONICS,
+    HOMEWARE,
+    CLOTHES
+}
+
 @Entity(tableName = "shoppingItems")
 @Serializable
 @TypeConverters(Converters::class)
@@ -18,6 +26,7 @@ data class ShoppingItem(
     val name: String = "",
     val description: String = "",
     val price: Double = 0.0,
+    val category: Category = Category.GROCERIES,
     val availability: Boolean = false,
     val storeId: String = ""
 )

--- a/app/src/main/java/ie/setu/mad2_assignment_one/data/dao/ShoppingListItemListDao.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/data/dao/ShoppingListItemListDao.kt
@@ -25,4 +25,7 @@ interface ShoppingListItemListDao {
 
     @Delete
     suspend fun delete(shoppingListItemList: ShoppingListItemList)
+
+    @Query("DELETE FROM shoppingListItemLists")
+    suspend fun clear()
 }

--- a/app/src/main/java/ie/setu/mad2_assignment_one/data/repository/ShoppingListItemListsRepository.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/data/repository/ShoppingListItemListsRepository.kt
@@ -9,4 +9,5 @@ interface ShoppingListItemListsRepository {
     suspend fun insertShoppingListItemList(shoppingListItemList: ShoppingListItemList)
     suspend fun deleteShoppingListItemList(shoppingListItemList: ShoppingListItemList)
     suspend fun updateShoppingListItemList(shoppingListItemList: ShoppingListItemList)
+    suspend fun clear()
 }

--- a/app/src/main/java/ie/setu/mad2_assignment_one/data/repository/offline/OfflineShoppingListItemListsRepository.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/data/repository/offline/OfflineShoppingListItemListsRepository.kt
@@ -16,4 +16,6 @@ class OfflineShoppingListItemListsRepository(private val shoppingListItemListDao
 
     override suspend fun updateShoppingListItemList(shoppingListItemList: ShoppingListItemList) = shoppingListItemListDao.update(shoppingListItemList)
 
+    override suspend fun clear() = shoppingListItemListDao.clear()
+
 }

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/ItemDetailsScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/ItemDetailsScreen.kt
@@ -44,6 +44,7 @@ import ie.setu.mad2_assignment_one.ui.theme.itemUnavailableBackgroundColor
 import ie.setu.mad2_assignment_one.ui.theme.itemUnavailableColor
 import ie.setu.mad2_assignment_one.viewmodel.ShoppingListViewModel
 import kotlinx.coroutines.launch
+import ie.setu.mad2_assignment_one.data.Category
 
 // Item Details Screen
 @OptIn(ExperimentalMaterial3Api::class)
@@ -145,7 +146,7 @@ fun ItemDetailsScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit,
 fun PreviewItemDetailsScreen() {
     ItemDetailsScreen(
         onNavigateBack = {},
-        item = ShoppingItem(0, 0,"AA", "aaa", 0.00, true),
+        item = ShoppingItem(0, 0, "AA", "aaa", 0.00, Category.GROCERIES, true),
         shoppingListViewModel = ShoppingListViewModel(
             shoppingListItemListsRepository = AppViewModelProvider.factory as ShoppingListItemListsRepository
         ),

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/ItemDetailsScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/ItemDetailsScreen.kt
@@ -36,8 +36,6 @@ import ie.setu.mad2_assignment_one.R
 import ie.setu.mad2_assignment_one.data.ShoppingItem
 import ie.setu.mad2_assignment_one.data.ShoppingListItem
 import ie.setu.mad2_assignment_one.data.repository.ShoppingListItemListsRepository
-import ie.setu.mad2_assignment_one.data.repository.ShoppingListItemsRepository
-import ie.setu.mad2_assignment_one.ui.AppViewModelProvider
 import ie.setu.mad2_assignment_one.ui.theme.itemAvailableBackgroundColor
 import ie.setu.mad2_assignment_one.ui.theme.itemAvailableColor
 import ie.setu.mad2_assignment_one.ui.theme.itemUnavailableBackgroundColor
@@ -108,6 +106,8 @@ fun ItemDetailsScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit,
                         Text(stringResource(R.string.out_of_stock), color = itemUnavailableColor)
                     }
                 }
+                // Item Category
+                Text(item.category.name, textAlign = TextAlign.Center, modifier= modifier.fillMaxWidth().padding(15.dp))
                 // Item Description
                 Text(item.description, textAlign = TextAlign.Center, modifier = modifier
                     .padding(15.dp)

--- a/app/src/main/java/ie/setu/mad2_assignment_one/viewmodel/ShoppingListViewModel.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/viewmodel/ShoppingListViewModel.kt
@@ -26,6 +26,7 @@ class ShoppingListViewModel(private val shoppingListItemListsRepository: Shoppin
     }
 
     suspend fun saveShoppingList(documentId: String = "default") {
+        shoppingListItemListsRepository.clear()
         shoppingListItemListsRepository.insertShoppingListItemList(ShoppingListItemList(0, _shoppingList.toList()))
         ShoppingListItemList.saveToFirestore(ShoppingListItemList(0, _shoppingList.toList()), documentId)
     }

--- a/app/src/main/res/raw/shopping_items.json
+++ b/app/src/main/res/raw/shopping_items.json
@@ -3,6 +3,7 @@
     "name": "Laptop",
     "description": "14-inch, 16GB RAM, 512GB SSD",
     "price": 1299.99,
+    "category": "ELECTRONICS",
     "availability": true,
     "storeId": "001"
   },
@@ -10,6 +11,7 @@
     "name": "Smartphone",
     "description": "6.5-inch display, 128GB storage",
     "price": 799.99,
+    "category": "ELECTRONICS",
     "availability": true,
     "storeId": "002"
   },
@@ -17,6 +19,7 @@
     "name": "Wireless Headphones",
     "description": "Noise-canceling, 30-hour battery",
     "price": 199.99,
+    "category": "ELECTRONICS",
     "availability": true,
     "storeId": "003"
   },
@@ -24,6 +27,7 @@
     "name": "Coffee Maker",
     "description": "12-cup programmable",
     "price": 49.99,
+    "category": "ELECTRONICS",
     "availability": false,
     "storeId": "001"
   },
@@ -31,6 +35,7 @@
     "name": "Gaming Mouse",
     "description": "RGB lighting, 16,000 DPI",
     "price": 59.99,
+    "category": "ELECTRONICS",
     "availability": true,
     "storeId": "002"
   },
@@ -38,6 +43,7 @@
     "name": "Keyboard",
     "description": "Mechanical, blue switches",
     "price": 89.99,
+    "category": "ELECTRONICS",
     "availability": true,
     "storeId": "003"
   },
@@ -45,6 +51,7 @@
     "name": "Backpack",
     "description": "Waterproof, 25L capacity",
     "price": 39.99,
+    "category": "HOMEWARE",
     "availability": true,
     "storeId": "001"
   },
@@ -52,6 +59,7 @@
     "name": "Desk Lamp",
     "description": "LED, dimmable",
     "price": 29.99,
+    "category": "HOMEWARE",
     "availability": false,
     "storeId": "002"
   },
@@ -59,6 +67,7 @@
     "name": "Smartwatch",
     "description": "Heart rate & sleep tracking",
     "price": 149.99,
+    "category": "ELECTRONICS",
     "availability": true,
     "storeId": "003"
   },
@@ -66,6 +75,7 @@
     "name": "External Hard Drive",
     "description": "2TB, USB 3.0",
     "price": 89.99,
+    "category": "ELECTRONICS",
     "availability": true,
     "storeId": "001"
   }

--- a/app/src/test/java/ie/setu/mad2_assignment_one/data/ShoppingItemTest.kt
+++ b/app/src/test/java/ie/setu/mad2_assignment_one/data/ShoppingItemTest.kt
@@ -11,12 +11,20 @@ class ShoppingItemTest {
     @BeforeEach
     fun setUp() {
         shoppingItem = ShoppingItem(
+            id = 0,
             imageRes = 123,
             name = "Sample Item",
             description = "This is a test item.",
             price = 19.99,
-            availability = true
+            category = Category.GROCERIES,
+            availability = true,
+            storeId = "NewStore1"
         )
+    }
+
+    @Test
+    fun getStoreID() {
+        assertEquals("NewStore1", shoppingItem.storeId)
     }
 
     @Test
@@ -40,6 +48,11 @@ class ShoppingItemTest {
     }
 
     @Test
+    fun getCategory() {
+        assertEquals(Category.GROCERIES, shoppingItem.category)
+    }
+
+    @Test
     fun getAvailability() {
         assertTrue(shoppingItem.availability)
     }
@@ -56,22 +69,40 @@ class ShoppingItemTest {
 
     @Test
     fun testToString() {
-        val expectedString = "ShoppingItem(imageRes=123, name=Sample Item, description=This is a test item., price=19.99, availability=true)"
+        val expectedString = "ShoppingItem(id=0, imageRes=123, name=Sample Item, description=This is a test item., price=19.99, category=GROCERIES, availability=true, storeId=NewStore1)"
         assertEquals(expectedString, shoppingItem.toString())
     }
 
     @Test
     fun testHashCode() {
-        val identicalItem = ShoppingItem(123, "Sample Item", "This is a test item.", 19.99, true)
+        val identicalItem = ShoppingItem(
+            id = 0,
+            imageRes = 123,
+            name = "Sample Item",
+            description = "This is a test item.",
+            price = 19.99,
+            category = Category.GROCERIES,
+            availability = true,
+            storeId = "NewStore1"
+        )
         assertEquals(shoppingItem.hashCode(), identicalItem.hashCode())
     }
 
     @Test
     fun testEquals() {
-        val identicalItem = ShoppingItem(123, "Sample Item", "This is a test item.", 19.99, true)
+        val identicalItem = ShoppingItem(
+            id = 0,
+            imageRes = 123,
+            name = "Sample Item",
+            description = "This is a test item.",
+            price = 19.99,
+            category = Category.GROCERIES,
+            availability = true,
+            storeId = "NewStore1"
+        )
         assertEquals(shoppingItem, identicalItem)
 
-        val differentItem = ShoppingItem(456, "Other Item", "Different description.", 9.99, false)
+        val differentItem = ShoppingItem(imageRes = 456, name="Other Item", description = "Different description.", price=9.99, category = Category.ELECTRONICS, availability = false)
         assertNotEquals(shoppingItem, differentItem)
     }
 }

--- a/app/src/test/java/ie/setu/mad2_assignment_one/data/ShoppingListItemTest.kt
+++ b/app/src/test/java/ie/setu/mad2_assignment_one/data/ShoppingListItemTest.kt
@@ -13,13 +13,16 @@ class ShoppingListItemTest {
     fun setUp() {
         // Setup common test data before each test
         shoppingItem = ShoppingItem(
+            id = 0,
             imageRes = 123,  // Example resource ID
             name = "Apple",
             description = "A fresh red apple",
+            category = Category.ELECTRONICS,
             price = 0.99,
-            availability = true
+            availability = true,
+            storeId = "NewStore1"
         )
-        shoppingListItem = ShoppingListItem(shoppingItem, 5)
+        shoppingListItem = ShoppingListItem(shoppingItem= shoppingItem, quantity = 5)
     }
 
     @Test
@@ -52,7 +55,7 @@ class ShoppingListItemTest {
     @Test
     fun testToString() {
         // Verify the string representation of the ShoppingListItem
-        val expectedString = "ShoppingListItem(shoppingItem=ShoppingItem(imageRes=123, name=Apple, description=A fresh red apple, price=0.99, availability=true), quantity=5)"
+        val expectedString = "ShoppingListItem(id=0, shoppingItem=ShoppingItem(id=0, imageRes=123, name=Apple, description=A fresh red apple, price=0.99, category=ELECTRONICS, availability=true, storeId=NewStore1), quantity=5)"
         assertEquals(expectedString, shoppingListItem.toString())
     }
 


### PR DESCRIPTION
## What

- New field `Category` added to `ShoppingItem` that consists of enums `HOMEWARE`, `ELECTRONICS`, `GROCERIES`, and `CLOTHES` . 
- `ItemDetailsScreen` now displays category for item . 
- Fix for ROOM (modify data issue) and Firebase database (error when un-auth'd user try to access).

## How

 - Enums added as `Category` to `ShoppingItem`. 
 - JSONs updated to reflect category. 
 - New type converters in place to handle enums for ROOM and Firebase . 
 - New `Text` element in `ItemDetailsScreen` now displays `item.category` . 

## Why

- Users may wish to know what item category their item is - may aid in querying/filtering later...