### PR TITLE
Add support for image profile uploading for user accounts and shopping item images

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,6 +13,9 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
+      <SelectionState runConfigName="MainActivity (2)">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,11 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth.ktx)
     implementation(libs.firebase.analytics)
+    implementation(libs.firebase.storage)
+
+    // Coil
+    implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
 
 
     // Jetpack Compose integration

--- a/app/src/main/java/ie/setu/mad2_assignment_one/MainActivity.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/MainActivity.kt
@@ -168,7 +168,7 @@ class MainActivity : ComponentActivity() {
                     composable<Account> {
                         AccountScreen(
                             bottomNavBar = { BottomNavigationBar(navController = navController, selectedOption = selectedOption.intValue, onOptionSelected = { selectedOption.intValue = it}) },
-                            onNavigateToHome = { navController.navigate(route = Main) }
+                            onNavigateToHome = { navController.navigate(route = Main); selectedOption.intValue = 0 }
                         )
                     }
                     // About Screen

--- a/app/src/main/java/ie/setu/mad2_assignment_one/data/InventoryDatabase.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/data/InventoryDatabase.kt
@@ -10,7 +10,7 @@ import ie.setu.mad2_assignment_one.data.dao.ShoppingListItemDao
 import ie.setu.mad2_assignment_one.data.dao.ShoppingListItemListDao
 import ie.setu.mad2_assignment_one.data.dao.StoreDao
 
-@Database(entities = [ShoppingItem::class, ShoppingListItem::class, ShoppingListItemList:: class, Store:: class], version = 2, exportSchema = false)
+@Database(entities = [ShoppingItem::class, ShoppingListItem::class, ShoppingListItemList:: class, Store:: class], version = 3, exportSchema = false)
 @TypeConverters(Converters::class)
 abstract class InventoryDatabase: RoomDatabase() {
     abstract fun shoppingItemDao(): ShoppingItemDao
@@ -23,7 +23,9 @@ abstract class InventoryDatabase: RoomDatabase() {
         private var Instance: InventoryDatabase? = null
         fun getDatabase(context: Context): InventoryDatabase {
             return Instance ?: synchronized(this) {
-                Room.databaseBuilder(context, InventoryDatabase::class.java, "local_database").fallbackToDestructiveMigration().build().also {
+                Room.databaseBuilder(context, InventoryDatabase::class.java, "local_database")
+                    .fallbackToDestructiveMigration(false)
+                    .build().also {
                     Instance = it
                 }
             }

--- a/app/src/main/java/ie/setu/mad2_assignment_one/data/ShoppingItem.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/data/ShoppingItem.kt
@@ -22,7 +22,7 @@ enum class Category {
 @TypeConverters(Converters::class)
 data class ShoppingItem(
     @PrimaryKey val id: Int = 0,
-    @DrawableRes val imageRes: Int = 0,  // Resource ID for images
+    @DrawableRes val imageRes: String = "",  // Resource ID for images
     val name: String = "",
     val description: String = "",
     val price: Double = 0.0,

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/ItemDetailsScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/ItemDetailsScreen.kt
@@ -146,7 +146,7 @@ fun ItemDetailsScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit,
 fun PreviewItemDetailsScreen() {
     ItemDetailsScreen(
         onNavigateBack = {},
-        item = ShoppingItem(0, 0, "AA", "aaa", 0.00, Category.GROCERIES, true),
+        item = ShoppingItem(0, "", "AA", "aaa", 0.00, Category.GROCERIES, true),
         shoppingListViewModel = ShoppingListViewModel(
             shoppingListItemListsRepository = AppViewModelProvider.factory as ShoppingListItemListsRepository
         ),

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/main/MainScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/main/MainScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,10 +51,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import coil3.compose.AsyncImage
+import com.google.firebase.Firebase
+import com.google.firebase.storage.storage
 import ie.setu.mad2_assignment_one.R
 import ie.setu.mad2_assignment_one.data.ShoppingItem
 import ie.setu.mad2_assignment_one.data.loadShoppingItems
 import ie.setu.mad2_assignment_one.ui.BottomNavigationBar
+import kotlinx.coroutines.tasks.await
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -209,6 +214,8 @@ fun ScrollableGrid(
     onItemClick: (ShoppingItem) -> Unit,
     items: List<ShoppingItem>
 ) {
+    val storage = Firebase.storage
+
     for (item in items.indices step 2) { // Step 2 to process items in pairs
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -218,6 +225,17 @@ fun ScrollableGrid(
             Column(
                 modifier = Modifier.weight(1f)
             ) {
+                var imageUrl1 = remember { mutableStateOf<String?>(null) }
+
+                LaunchedEffect(items[item].imageRes) {
+                    try {
+                        val ref = storage.reference.child(items[item].imageRes)
+                        imageUrl1.value = ref.downloadUrl.await().toString()
+                    } catch (_: Exception) {
+                        imageUrl1.value = null
+                    }
+                }
+
                 Card(
                     modifier = Modifier
                         .padding(8.dp)
@@ -230,11 +248,19 @@ fun ScrollableGrid(
                             .align(Alignment.CenterHorizontally)
                             .padding(top = 10.dp)
                     ) {
-                        Image(
-                            imageVector = Icons.Default.Star,
-                            contentDescription = "${items[item].name} image",
-                            modifier = modifier.size(50.dp)
-                        )
+                        if (imageUrl1.value != null) {
+                            AsyncImage(
+                                model = imageUrl1.value,
+                                contentDescription = "${items[item].name} image",
+                                modifier = modifier.size(80.dp)
+                            )
+                        } else {
+                            Image(
+                                imageVector = Icons.Default.Star,
+                                contentDescription = "${items[item].name} image",
+                                modifier = modifier.size(50.dp)
+                            )
+                        }
                     }
                     Row(
                         modifier = modifier.align(Alignment.CenterHorizontally)
@@ -254,6 +280,17 @@ fun ScrollableGrid(
                 Column(
                     modifier = Modifier.weight(1f)
                 ) {
+                    var imageUrl2 = remember { mutableStateOf<String?>(null) }
+
+                    LaunchedEffect(items[item + 1].imageRes) {
+                        try {
+                            val ref = storage.reference.child(items[item + 1].imageRes)
+                            imageUrl2.value = ref.downloadUrl.await().toString()
+                        } catch (_: Exception) {
+                            imageUrl2.value = null
+                        }
+                    }
+
                     Card(
                         modifier = Modifier
                             .padding(8.dp)
@@ -266,11 +303,19 @@ fun ScrollableGrid(
                                 .align(Alignment.CenterHorizontally)
                                 .padding(top = 10.dp)
                         ) {
-                            Image(
-                                imageVector = Icons.Default.Star,
-                                contentDescription = "${items[item + 1].name} image",
-                                modifier = modifier.size(50.dp)
-                            )
+                            if (imageUrl2.value != null) {
+                                AsyncImage(
+                                    model = imageUrl2.value,
+                                    contentDescription = "${items[item + 1].name} image",
+                                    modifier = modifier.size(80.dp)
+                                )
+                            } else {
+                                Image(
+                                    imageVector = Icons.Default.Star,
+                                    contentDescription = "${items[item + 1].name} image",
+                                    modifier = modifier.size(50.dp)
+                                )
+                            }
                         }
                         Row(
                             modifier = modifier.align(Alignment.CenterHorizontally)
@@ -286,7 +331,6 @@ fun ScrollableGrid(
                 }
             } else {
                 // If there's an odd item count, add empty space to keep layout balanced
-                // https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#Spacer(androidx.compose.ui.Modifier)
                 Spacer(modifier = Modifier.weight(1f))
             }
         }

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/user/AccountScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/user/AccountScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -17,11 +19,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import coil3.compose.AsyncImage
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import ie.setu.mad2_assignment_one.ui.BottomNavigationBar
@@ -44,10 +48,18 @@ fun AccountScreen(
             var user by remember { mutableStateOf(Firebase.auth.currentUser) }
             if (user != null) {
                 // check if user logged in
+                // User Photo
+                Row(modifier = Modifier
+                    .align(Alignment.CenterHorizontally)) {
+                    AsyncImage(user!!.photoUrl, contentDescription = "${user!!.displayName} profile picture ", modifier = Modifier.size(250.dp).clip(
+                        CircleShape
+                    ))
+                }
+                // Display name
                 Row(modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .padding(bottom = 20.dp)) {
-                    Text(text ="Hello ${user!!.email} ! ", fontSize = 25.sp) // TODO change this to user.displayName after auth rework.
+                    Text(text ="Hello ${user!!.displayName} ! ", fontSize = 25.sp)
                 }
                 Row(modifier = Modifier.align(Alignment.CenterHorizontally)) {
                     Button(onClick = {

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/user/RegisterScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/user/RegisterScreen.kt
@@ -2,6 +2,8 @@ package ie.setu.mad2_assignment_one.ui.user
 
 import android.content.Context
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -26,25 +28,57 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import android.net.Uri
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import coil3.compose.rememberAsyncImagePainter
 import ie.setu.mad2_assignment_one.R
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.auth.userProfileChangeRequest
 import com.google.firebase.ktx.Firebase
+import com.google.firebase.storage.ktx.storage
+import kotlinx.coroutines.launch
 
 // Registration Screen
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RegisterScreen(modifier: Modifier = Modifier, context: Context, onNavigateToLoginScreen: () -> Unit) {
+    // Display name string
+    var displayNameString by remember { mutableStateOf("") }
     // Email string
     var email by remember { mutableStateOf("") }
     // Password string
     var password by remember { mutableStateOf("") }
+    // URI String
+    var imageUri by remember { mutableStateOf<Uri?>(null) }
+    // Image URI Launcher
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        imageUri = uri
+    }
+    // Percentage Progress for image upload
+    var uploadProgress by remember { mutableIntStateOf(0) }
+    // co routine scope for bringing user back on successful image upload
+    var scope = rememberCoroutineScope()
     Column {
-        // Besco Icon
-        Row (modifier = modifier
-            .align(Alignment.CenterHorizontally)
-            .padding(top = 50.dp)) {
-            Image(imageVector = Icons.Outlined.ShoppingCart, contentDescription = stringResource(R.string.besco_logo_content_description), modifier = modifier.size(150.dp))
+        // Display profile picture before upload
+        if (imageUri?.path?.isEmpty() == false) {
+            Row(
+                modifier = modifier
+                    .align(Alignment.CenterHorizontally)
+            ) {
+                Image(
+                    painter = rememberAsyncImagePainter(imageUri),
+                    contentDescription = "My Image",
+                    modifier = modifier.size(150.dp)
+                )
+            }
+        } else {
+            // Besco Icon
+            Row (modifier = modifier
+                .align(Alignment.CenterHorizontally)) {
+                Image(imageVector = Icons.Outlined.ShoppingCart, contentDescription = stringResource(R.string.besco_logo_content_description), modifier = modifier.size(150.dp))
+            }
         }
         // Content
         Row(
@@ -73,10 +107,29 @@ fun RegisterScreen(modifier: Modifier = Modifier, context: Context, onNavigateTo
                 text = stringResource(R.string.register_screen_paragraph_2),
                 textAlign = TextAlign.Center)
         }
+        // Upload button
+        Row(modifier = modifier
+            .padding(top = 25.dp)
+            .align(Alignment.CenterHorizontally)) {
+            Button(onClick = {
+                launcher.launch("image/*")
+            }
+            ) {
+                Text("Upload Profile Picture")
+            }
+        }
+        // Display Name
+        Row(
+            modifier = modifier
+                .padding(top = 25.dp)
+                .align(Alignment.CenterHorizontally)
+        ) {
+            TextField(value = displayNameString, label = { Text(stringResource(R.string.display_name)) }, onValueChange = { displayNameString = it })
+        }
         // Email
         Row(
             modifier = modifier
-                .padding(top = 50.dp)
+                .padding(top = 25.dp)
                 .align(Alignment.CenterHorizontally)
         ) {
             TextField(value = email, label = { Text(stringResource(R.string.email_text)) }, onValueChange = { email = it })
@@ -97,6 +150,7 @@ fun RegisterScreen(modifier: Modifier = Modifier, context: Context, onNavigateTo
         ) {
             Button(
                 onClick = {
+                    if (!email.isEmpty() && !password.isEmpty()) {
                     val auth: FirebaseAuth = Firebase.auth
                     // Send Request to Firebase
                     auth.createUserWithEmailAndPassword(email, password)
@@ -104,6 +158,53 @@ fun RegisterScreen(modifier: Modifier = Modifier, context: Context, onNavigateTo
                             if (task.isSuccessful) {
                                 // Toast user their registration is success
                                 Toast.makeText(context, "Registration successful! Bringing you to login screen...", Toast.LENGTH_LONG).show()
+                                // Firebase storage path for images
+                                var storagePath =
+                                    Firebase.storage.reference.child("/profile_pictures/$email")
+                                // Upload file
+                                val uploadTask = storagePath.putFile(imageUri!!)
+                                // If upload fail...
+                                uploadTask.addOnFailureListener {
+                                    // Add toast to alert the user
+                                    Toast.makeText(
+                                        context,
+                                        "Unable to upload profile image - please check the file and try again.",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                    uploadProgress = -1
+                                }.addOnSuccessListener { // if upload success...
+                                    // Also add toast to alert the user
+                                    Toast.makeText(
+                                        context,
+                                        "Profile image uploaded successfully.",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                    uploadProgress = -1
+                                }
+                                // Modify user profile with photoUrl and displayName
+                                if (auth.currentUser != null && !displayNameString.isEmpty()) {
+                                    uploadTask.addOnSuccessListener {
+                                        storagePath.downloadUrl.addOnSuccessListener { uri ->
+                                            val user = auth.currentUser
+                                            val profileUpdate = userProfileChangeRequest {
+                                                displayName = displayNameString
+                                                photoUri = uri
+                                            }
+                                            user?.updateProfile(profileUpdate)
+                                                ?.addOnSuccessListener {
+                                                    Toast.makeText(context, "Profile updated!", Toast.LENGTH_SHORT).show()
+                                                    scope.launch {
+                                                        onNavigateToLoginScreen()
+                                                    }
+                                                }
+                                                ?.addOnFailureListener {
+                                                    Toast.makeText(context, "Failed to update profile.", Toast.LENGTH_SHORT).show()
+                                                }
+                                        }
+                                    }.addOnFailureListener {
+                                        Toast.makeText(context, "Failed to upload image.", Toast.LENGTH_SHORT).show()
+                                    }
+                                }
                                 // Bring user to login screen
                                 onNavigateToLoginScreen()
                             } else {
@@ -112,6 +213,9 @@ fun RegisterScreen(modifier: Modifier = Modifier, context: Context, onNavigateTo
                                 Toast.makeText(context, task.exception?.message ?: "Failure unknown - contact the app developer!", Toast.LENGTH_LONG).show()
                             }
                         }
+                    } else {
+                        Toast.makeText(context, "User email and password fields empty - please fill before trying again.", Toast.LENGTH_SHORT).show()
+                    }
                 },
             ) {
                 Text(stringResource(R.string.register_button_text))

--- a/app/src/main/res/raw/shopping_items.json
+++ b/app/src/main/res/raw/shopping_items.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "Laptop",
+    "imageRes" : "/shopping_items/laptop.png",
     "description": "14-inch, 16GB RAM, 512GB SSD",
     "price": 1299.99,
     "category": "ELECTRONICS",
@@ -9,6 +10,7 @@
   },
   {
     "name": "Smartphone",
+    "imageRes": "/shopping_items/smartphone.png",
     "description": "6.5-inch display, 128GB storage",
     "price": 799.99,
     "category": "ELECTRONICS",
@@ -17,6 +19,7 @@
   },
   {
     "name": "Wireless Headphones",
+    "imageRes": "/shopping_items/wireless_headphones.png",
     "description": "Noise-canceling, 30-hour battery",
     "price": 199.99,
     "category": "ELECTRONICS",
@@ -25,6 +28,7 @@
   },
   {
     "name": "Coffee Maker",
+    "imageRes": "/shopping_items/coffee_maker.png",
     "description": "12-cup programmable",
     "price": 49.99,
     "category": "ELECTRONICS",
@@ -33,6 +37,7 @@
   },
   {
     "name": "Gaming Mouse",
+    "imageRes": "/shopping_items/gaming_mouse.png",
     "description": "RGB lighting, 16,000 DPI",
     "price": 59.99,
     "category": "ELECTRONICS",
@@ -41,6 +46,7 @@
   },
   {
     "name": "Keyboard",
+    "imageRes": "/shopping_items/keyboard.png",
     "description": "Mechanical, blue switches",
     "price": 89.99,
     "category": "ELECTRONICS",
@@ -49,6 +55,7 @@
   },
   {
     "name": "Backpack",
+    "imageRes": "/shopping_items/backpack.png",
     "description": "Waterproof, 25L capacity",
     "price": 39.99,
     "category": "HOMEWARE",
@@ -57,6 +64,7 @@
   },
   {
     "name": "Desk Lamp",
+    "imageRes": "/shopping_items/desk_lamp.png",
     "description": "LED, dimmable",
     "price": 29.99,
     "category": "HOMEWARE",
@@ -64,7 +72,8 @@
     "storeId": "002"
   },
   {
-    "name": "Smartwatch",
+    "name": "Smart Watch",
+    "imageRes": "/shopping_items/smart_watch.png",
     "description": "Heart rate & sleep tracking",
     "price": 149.99,
     "category": "ELECTRONICS",
@@ -73,6 +82,7 @@
   },
   {
     "name": "External Hard Drive",
+    "imageRes": "/shopping_items/external_hard_drive.png",
     "description": "2TB, USB 3.0",
     "price": 89.99,
     "category": "ELECTRONICS",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,5 @@
     <string name="account_icon">Account Icon</string>
     <string name="about_icon">About Icon</string>
     <string name="default_web_client_id">691987119649-k2sq8lo8dtbd3o0cmlq8ebojgcl7ubsg.apps.googleusercontent.com</string>
+    <string name="display_name">Display Name</string>
 </resources>

--- a/app/src/test/java/ie/setu/mad2_assignment_one/data/ShoppingItemTest.kt
+++ b/app/src/test/java/ie/setu/mad2_assignment_one/data/ShoppingItemTest.kt
@@ -12,7 +12,7 @@ class ShoppingItemTest {
     fun setUp() {
         shoppingItem = ShoppingItem(
             id = 0,
-            imageRes = 123,
+            imageRes = "/shopping_items/test_item.png",
             name = "Sample Item",
             description = "This is a test item.",
             price = 19.99,
@@ -29,7 +29,7 @@ class ShoppingItemTest {
 
     @Test
     fun getImageRes() {
-        assertEquals(123, shoppingItem.imageRes)
+        assertEquals("/shopping_items/test_item.png", shoppingItem.imageRes)
     }
 
     @Test
@@ -60,7 +60,7 @@ class ShoppingItemTest {
     @Test
     fun testCopy() {
         val newItem = shoppingItem.copy(price = 25.99, availability = false)
-        assertEquals(123, newItem.imageRes)
+        assertEquals("/shopping_items/test_item.png", newItem.imageRes)
         assertEquals("Sample Item", newItem.name)
         assertEquals("This is a test item.", newItem.description)
         assertEquals(25.99, newItem.price, 0.01)
@@ -69,7 +69,7 @@ class ShoppingItemTest {
 
     @Test
     fun testToString() {
-        val expectedString = "ShoppingItem(id=0, imageRes=123, name=Sample Item, description=This is a test item., price=19.99, category=GROCERIES, availability=true, storeId=NewStore1)"
+        val expectedString = "ShoppingItem(id=0, imageRes=/shopping_items/test_item.png, name=Sample Item, description=This is a test item., price=19.99, category=GROCERIES, availability=true, storeId=NewStore1)"
         assertEquals(expectedString, shoppingItem.toString())
     }
 
@@ -77,7 +77,7 @@ class ShoppingItemTest {
     fun testHashCode() {
         val identicalItem = ShoppingItem(
             id = 0,
-            imageRes = 123,
+            imageRes = "/shopping_items/test_item.png",
             name = "Sample Item",
             description = "This is a test item.",
             price = 19.99,
@@ -92,7 +92,7 @@ class ShoppingItemTest {
     fun testEquals() {
         val identicalItem = ShoppingItem(
             id = 0,
-            imageRes = 123,
+            imageRes = "/shopping_items/test_item.png",
             name = "Sample Item",
             description = "This is a test item.",
             price = 19.99,
@@ -102,7 +102,7 @@ class ShoppingItemTest {
         )
         assertEquals(shoppingItem, identicalItem)
 
-        val differentItem = ShoppingItem(imageRes = 456, name="Other Item", description = "Different description.", price=9.99, category = Category.ELECTRONICS, availability = false)
+        val differentItem = ShoppingItem(imageRes = "/shopping_items/test_item.png", name="Other Item", description = "Different description.", price=9.99, category = Category.ELECTRONICS, availability = false)
         assertNotEquals(shoppingItem, differentItem)
     }
 }

--- a/app/src/test/java/ie/setu/mad2_assignment_one/data/ShoppingListItemTest.kt
+++ b/app/src/test/java/ie/setu/mad2_assignment_one/data/ShoppingListItemTest.kt
@@ -14,7 +14,7 @@ class ShoppingListItemTest {
         // Setup common test data before each test
         shoppingItem = ShoppingItem(
             id = 0,
-            imageRes = 123,  // Example resource ID
+            imageRes = "/shopping_items/test_item.png",  // Example resource ID
             name = "Apple",
             description = "A fresh red apple",
             category = Category.ELECTRONICS,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
-agp = "8.8.2"
+agp = "8.9.2"
+coilCompose = "3.1.0"
 core = "1.6.1"
 credentialsPlayServicesAuth = "1.5.0"
 desugar_jdk_libs = "2.1.5"
@@ -36,11 +37,14 @@ androidx-navigation-ui = { module = "androidx.navigation:navigation-ui", version
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntime" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coilCompose" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-firestore-ktx = { module = "com.google.firebase:firebase-firestore-ktx" }
+firebase-storage = { module = "com.google.firebase:firebase-storage" }
 googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Feb 10 16:01:25 GMT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What

- Image support for shopping items added in app. 
- Profile picture and display name for Firebase auth added for both email/password and GAuth . 
- Bug fixed where bottom app bar selection does not change on log in.

## How

- `shoppingItem` has modified attribute `imageRes` that takes in string which contains where the `shoppingItem` image is stored on Firebase. Firebase image loading only - no support for local image loading (via local database) to simplify image loading.
- On successful user registering via email/password, profile image and display name is modified on the new user, and a Toast is provided to notify the user of successful modification of their account. 
- `onNavigateToHome` option on `MainActivity` Account section has new line which changed the number for `selectedOption` to `0`. 

## Why 
- Users may have multiple shopping items labelled the same, and the image may help them to differentiate between shopping items.
- Users may like to know their profile is customised via profile and display name. 
- Users can be confused as to what screen is currently loaded by looking at the bottom navigation screen - fixing the bug allows them to distinctively know what screen they have actually selected. 