### PR TITLE
add category filter dialog + logic

### DIFF
--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/main/MainScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/main/MainScreen.kt
@@ -94,7 +94,7 @@ fun MainScreen(
                 actions = {
                     // Filter drop down menu
                     IconButton(onClick = { expanded = !expanded }) {
-                        Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                        Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.more_options))
                         DropdownMenu(
                             expanded = expanded,
                             onDismissRequest = { expanded = false }
@@ -126,7 +126,7 @@ fun MainScreen(
         if (showDialog) {
             AlertDialog(
                 onDismissRequest = { showDialog = false },
-                title = { Text("Choose a category to filter items by") },
+                title = { Text(stringResource(R.string.choose_category_filter_string_prompt)) },
                 text = {
                     Column {
                         options.forEach { option ->
@@ -156,12 +156,12 @@ fun MainScreen(
                             items.toMutableList()
                         }
                     }) {
-                        Text("OK")
+                        Text(stringResource(R.string.dialog_confirm))
                     }
                 },
                 dismissButton = {
                     TextButton(onClick = { showDialog = false }) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.dialog_cancel))
                     }
                 }
             )

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/main/MainScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/main/MainScreen.kt
@@ -17,24 +17,32 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.KeyboardArrowUp
 import androidx.compose.material.icons.outlined.ShoppingCart
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -42,6 +50,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -72,12 +81,30 @@ fun MainScreen(
     onNavigateChooseStore: () -> Unit,
     bottomNavBar: @Composable () -> Unit,
 ) {
+    var expanded by remember { mutableStateOf(false) }
+    var showDialog by remember { mutableStateOf(false) }
+    val options = listOf("All") + items.map{ it.category.name }.distinct()
+    var selectedOption by remember { mutableStateOf(options[0]) }
+    var itemsToDisplay = remember { items.toMutableList() }
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.main_screen_top_bar_title)) },
                 modifier = modifier,
                 actions = {
+                    // Filter drop down menu
+                    IconButton(onClick = { expanded = !expanded }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                        DropdownMenu(
+                            expanded = expanded,
+                            onDismissRequest = { expanded = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Filter by category") },
+                                onClick = { showDialog = true }
+                            )
+                        }
+                    }
                     // Choose Store Button
                     Button(
                         onClick = { onNavigateChooseStore() }, // needs to be defined for store selection in later iteration.
@@ -95,6 +122,50 @@ fun MainScreen(
         },
         bottomBar = { bottomNavBar() }
     ) { padding ->
+        // Dialog Box to filter categories (not shown unless showDialog is toggled true) .
+        if (showDialog) {
+            AlertDialog(
+                onDismissRequest = { showDialog = false },
+                title = { Text("Choose a category to filter items by") },
+                text = {
+                    Column {
+                        options.forEach { option ->
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { selectedOption = option }
+                                    .padding(vertical = 4.dp)
+                            ) {
+                                RadioButton(
+                                    selected = (option == selectedOption),
+                                    onClick = { selectedOption = option }
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(option)
+                            }
+                        }
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = {
+                        showDialog = false
+                        itemsToDisplay = if (selectedOption != "All") {
+                            items.filter{ it.category.name == selectedOption }.toMutableList()
+                        } else {
+                            items.toMutableList()
+                        }
+                    }) {
+                        Text("OK")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showDialog = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
+        }
         Column(modifier
             .verticalScroll(scrollState)
             .padding(bottom = 50.dp)) {
@@ -189,7 +260,7 @@ fun MainScreen(
             ) {
                 Text(stringResource(R.string.main_screen_user_swipe_prompt), fontSize = 26.sp)
             }
-            ScrollableGrid(onItemClick = onItemClick, items = items)
+            ScrollableGrid(onItemClick = onItemClick, items = itemsToDisplay)
         }
 
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,8 @@
     <string name="about_icon">About Icon</string>
     <string name="default_web_client_id">691987119649-k2sq8lo8dtbd3o0cmlq8ebojgcl7ubsg.apps.googleusercontent.com</string>
     <string name="display_name">Display Name</string>
+    <string name="more_options">More options</string>
+    <string name="choose_category_filter_string_prompt">Choose a category to filter items by</string>
+    <string name="dialog_confirm">OK</string>
+    <string name="dialog_cancel">Cancel</string>
 </resources>


### PR DESCRIPTION
## What:

- New dialog allows filtering of `category` field in `shoppingItem` display on Home Screen. 
- Dialog is accessible from `...` menu on `MainScreen`  -> `TopAppBar` . 

## How:

- `map.filter` filters on `category` field based on `selectedOption` from new dialog modal.
- New dialog modal checks for available categories based on the list of `shoppingItem` entries.
- Boolean logic to enable/disable menu and dialog in place.

## Why:

- User may wish to look at specific item categories - this feature allows them to do that.

