### PR TITLE
Remove about from BottomNavBar and add About action to Account TopAppBar

### DIFF
--- a/app/src/main/java/ie/setu/mad2_assignment_one/MainActivity.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/MainActivity.kt
@@ -168,13 +168,15 @@ class MainActivity : ComponentActivity() {
                     composable<Account> {
                         AccountScreen(
                             bottomNavBar = { BottomNavigationBar(navController = navController, selectedOption = selectedOption.intValue, onOptionSelected = { selectedOption.intValue = it}) },
-                            onNavigateToHome = { navController.navigate(route = Main); selectedOption.intValue = 0 }
+                            onNavigateToHome = { navController.navigate(route = Main); selectedOption.intValue = 0 },
+                            onNavigateToAbout = { navController.navigate(route = About) }
                         )
                     }
                     // About Screen
                     composable<About> {
                         AboutScreen(
                             bottomNavBar = { BottomNavigationBar(navController = navController, selectedOption = selectedOption.intValue, onOptionSelected = { selectedOption.intValue = it}) },
+                            onNavigateBack = { navController.popBackStack() }
                         )
                     }
                 }

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/AboutScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/AboutScreen.kt
@@ -7,9 +7,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -25,10 +27,17 @@ import androidx.navigation.NavController
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AboutScreen(bottomNavBar: @Composable () -> Unit){
+fun AboutScreen(bottomNavBar: @Composable () -> Unit, onNavigateBack: () -> Unit){
     Scaffold(
         topBar = { TopAppBar(
             title = { Text("About") },
+            navigationIcon = {
+                IconButton(onClick = {
+                    onNavigateBack()
+                }) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back Arrow")
+                }
+            }
         ) },
         bottomBar = { bottomNavBar() },
     ) { padding ->
@@ -76,6 +85,7 @@ fun AboutScreen(bottomNavBar: @Composable () -> Unit){
 @Preview
 fun PreviewAboutScreen(){
     AboutScreen(
-        bottomNavBar = { BottomNavigationBar(navController = NavController(LocalContext.current), selectedOption = 2, onOptionSelected = {}) }
+        bottomNavBar = { BottomNavigationBar(navController = NavController(LocalContext.current), selectedOption = 2, onOptionSelected = {}) },
+        onNavigateBack = {},
     )
 }

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/BottomNavBar.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/BottomNavBar.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.runtime.Composable
@@ -27,9 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.compose.currentBackStackEntryAsState
 import ie.setu.mad2_assignment_one.R
-import ie.setu.mad2_assignment_one.navigation.About
 import ie.setu.mad2_assignment_one.navigation.Main
 import ie.setu.mad2_assignment_one.navigation.Account
 import ie.setu.mad2_assignment_one.navigation.TopLevelRoute
@@ -43,7 +40,6 @@ fun BottomNavigationBar(
     val topLevelRoutes = listOf(
         TopLevelRoute("Shopping", Main ,Icons.Filled.ShoppingCart),
         TopLevelRoute("Account", Account, Icons.Filled.Person),
-        TopLevelRoute("About", About, Icons.Filled.Info)
     )
     BottomAppBar {
         Row(
@@ -67,9 +63,9 @@ fun BottomNavigationBar(
                                     saveState = true
                                 }
                                 // Avoid multiple copies of the same destination when
-                                // reselecting the same item
+                                // re-selecting the same item
                                 launchSingleTop = true
-                                // Restore state when reselecting a previously selected item
+                                // Restore state when re-selecting a previously selected item
                                 restoreState = true
                             }
                         }
@@ -85,8 +81,7 @@ fun BottomNavigationBar(
                             imageVector = topLevelRoute.icon,
                             contentDescription = stringResource(id = when(index) {
                                 0 -> R.string.shopping_list_icon
-                                1 -> R.string.account_icon
-                                else -> R.string.about_icon
+                                else -> R.string.account_icon
                             })
                         )
                         Text(text = topLevelRoute.name)

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/user/AccountScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/user/AccountScreen.kt
@@ -7,8 +7,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -36,8 +40,16 @@ import ie.setu.mad2_assignment_one.ui.BottomNavigationBar
 fun AccountScreen(
     bottomNavBar: @Composable () -> Unit,
     onNavigateToHome: () -> Unit,
+    onNavigateToAbout: () -> Unit,
 ) {
-    val topBar = @Composable { TopAppBar(title = { Text("Account") }) }
+    val topBar = @Composable { TopAppBar(title = { Text("Account") }, actions = {
+        // About Icon and clickable topLevelRoute
+        IconButton(onClick = {
+            onNavigateToAbout()
+        }) {
+            Icon(Icons.Filled.Info, "About Icon")
+        }
+    }) }
     Scaffold(
         topBar = { topBar() },
         bottomBar = { bottomNavBar() })
@@ -81,5 +93,5 @@ fun AccountScreen(
 @Composable
 @Preview
 fun PreviewAccountScreen() {
-    AccountScreen(bottomNavBar = { BottomNavigationBar(navController = NavController(context = LocalContext.current), selectedOption = 1, onOptionSelected = {}) }, onNavigateToHome = {})
+    AccountScreen(bottomNavBar = { BottomNavigationBar(navController = NavController(context = LocalContext.current), selectedOption = 1, onOptionSelected = {}) }, onNavigateToHome = {}, onNavigateToAbout = {})
 }


### PR DESCRIPTION
## What:

- `About` screen has been moved from `BottomNavBar` to `Account` screen under Info button . 

## How:

- `TopLevelEntry` route no longer in use for `BottomNavBar` for `About` . 
- `IconButton` in place on `TopAppBar` of `Account` . 

## Why:

- For grading purposes, I don't have a particular reason for this change. I personally think the `BottomNavBar` looks more empty now. 