### PR TITLE
add confirm delete all dialog to shopping list + fix account bug

### DIFF
--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/shopping/ShoppingListScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/shopping/ShoppingListScreen.kt
@@ -74,13 +74,13 @@ fun ShoppingListScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit
         if (showModal.value) {
             AlertDialog(
                 icon = {
-                    Icon(Icons.Default.Warning, contentDescription = "Warning Icon")
+                    Icon(Icons.Default.Warning, contentDescription = stringResource(R.string.warning_icon))
                 },
                 title = {
-                    Text(text = "Are you sure?")
+                    Text(text = stringResource(R.string.alert_dialog_title))
                 },
                 text = {
-                    Text(text = "Your entire list will be deleted!")
+                    Text(text = stringResource(R.string.alert_dialog_msg))
                 },
                 onDismissRequest = {
                     showModal.value = !showModal.value
@@ -98,7 +98,7 @@ fun ShoppingListScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit
                             }
                         }
                     ) {
-                        Text("Confirm")
+                        Text(stringResource(R.string.modal_confirm))
                     }
                 },
                 dismissButton = {
@@ -107,7 +107,7 @@ fun ShoppingListScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit
                              showModal.value = !showModal.value
                         }
                     ) {
-                        Text("Dismiss")
+                        Text(stringResource(R.string.modal_dismiss))
                     }
                 }
             )

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/shopping/ShoppingListScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/shopping/ShoppingListScreen.kt
@@ -74,13 +74,13 @@ fun ShoppingListScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit
         if (showModal.value) {
             AlertDialog(
                 icon = {
-                    Icon(Icons.Default.Warning, contentDescription = "Warning Icon")
+                    Icon(Icons.Default.Warning, contentDescription = stringResource(R.string.warning_icon))
                 },
                 title = {
-                    Text(text = "Are you sure?")
+                    Text(text = stringResource(R.string.alert_dialog_title))
                 },
                 text = {
-                    Text(text = "Your entire list will be deleted!")
+                    Text(text = stringResource(R.string.alert_dialog_msg))
                 },
                 onDismissRequest = {
                     showModal.value = !showModal.value

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/user/AccountScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/user/AccountScreen.kt
@@ -58,7 +58,7 @@ fun AccountScreen(
             .padding(padding)
             .fillMaxSize(), verticalArrangement = Arrangement.Center) {
             var user by remember { mutableStateOf(Firebase.auth.currentUser) }
-            if (user != null) {
+            if (user!!.displayName != null || user!!.email != null) {
                 // check if user logged in
                 // User Photo
                 Row(modifier = Modifier

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,9 @@
     <string name="choose_category_filter_string_prompt">Choose a category to filter items by</string>
     <string name="dialog_confirm">OK</string>
     <string name="dialog_cancel">Cancel</string>
+    <string name="warning_icon">Warning Icon</string>
+    <string name="alert_dialog_title">Are you sure?</string>
+    <string name="alert_dialog_msg">Your entire list will be deleted!</string>
+    <string name="modal_confirm">Confirm</string>
+    <string name="modal_dismiss">Dismiss</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,7 @@
     <string name="choose_category_filter_string_prompt">Choose a category to filter items by</string>
     <string name="dialog_confirm">OK</string>
     <string name="dialog_cancel">Cancel</string>
+    <string name="warning_icon">Warning Icon</string>
+    <string name="alert_dialog_title">Are you sure?</string>
+    <string name="alert_dialog_msg">Your entire list will be deleted!</string>
 </resources>


### PR DESCRIPTION
## What:

- Confirm Dialog for when a user wishes to delete their entire shopping list via `Delete All` button has been added. 
- Account Bug, where anonymous logins to display shopping item images via Firebase, meant that `Account` screen displayed `null` display name. This bug is now fixed.

## How:

- Alert Dialog with message `Your entire list will be deleted!` is implemented through boolean `showModal` on `ShoppingListScreen` . 
- Checks for `user.email` and `user.displayName` being `null` fixes the anonymous login being recognised as a valid user login. 

## Why:

- Alerts user of a more serious modification to their app. 
- User can now log in with their own account.