### PR TITLE
add display store name on choose store on home screen

### DIFF
--- a/app/src/main/java/ie/setu/mad2_assignment_one/MainActivity.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/MainActivity.kt
@@ -118,7 +118,8 @@ class MainActivity : ComponentActivity() {
                                     onNavigateChooseStore = {
                                         navController.navigate(route = SelectStore)
                                     },
-                                    bottomNavBar = { BottomNavigationBar(navController = navController, selectedOption = selectedOption.intValue, onOptionSelected = { selectedOption.intValue = it}) }
+                                    bottomNavBar = { BottomNavigationBar(navController = navController, selectedOption = selectedOption.intValue, onOptionSelected = { selectedOption.intValue = it}) },
+                                    chooseStoreText = storeViewModel.selectedStore.value?.name ?: context.getString(R.string.choose_store_button_text)
                                 )
                             }
                         }

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/main/MainScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/main/MainScreen.kt
@@ -80,6 +80,7 @@ fun MainScreen(
     items: List<ShoppingItem>,
     onNavigateChooseStore: () -> Unit,
     bottomNavBar: @Composable () -> Unit,
+    chooseStoreText: String = LocalContext.current.getString(R.string.choose_store_button_text),
 ) {
     var expanded by remember { mutableStateOf(false) }
     var showDialog by remember { mutableStateOf(false) }
@@ -115,7 +116,7 @@ fun MainScreen(
                             Icons.Filled.Place,
                             contentDescription = stringResource(R.string.choose_store_button_content_description)
                         )
-                        Text(stringResource(R.string.choose_store_button_text))
+                        Text(chooseStoreText)
                     }
                 }
             )


### PR DESCRIPTION
## What:

- `Choose Store` button now displays store name on user store selection. 

## How:

- `chooseStoreText` parameter added to `Main` Screen . 
- Check to see if `storeViewModel.selectedStore.name` is `null`. If not, `chooseStoreText` is `storeViewModel.selectedStore.name` which is displayed on the `Choose Store` button on `MainScreen` . 

## Why:

- Users can now see what their chosen store is, even after Toast message that displays it.