### PR TITLE
Add note to shopping list functionality

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -3,12 +3,26 @@
   <component name="AndroidTestResultsUserPreferences">
     <option name="androidTestResultsTableState">
       <map>
+        <entry key="-1908349581">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_35" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1530058360">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
                 <map>
                   <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_35" value="120" />
                   <entry key="Pixel_4_API_34" value="120" />
                   <entry key="Tests" value="360" />
                 </map>
@@ -48,6 +62,7 @@
               <option name="preferredColumnWidths">
                 <map>
                   <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_35" value="120" />
                   <entry key="Pixel_4_API_34" value="120" />
                   <entry key="Tests" value="360" />
                 </map>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -16,6 +16,15 @@
       <SelectionState runConfigName="MainActivity (2)">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="ShoppingListItemListTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="testSaveToFirestore_savesDataCorrectly()">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="testReadFromFirestore_returnsNullWhenDocumentDoesNotExist()">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -25,6 +25,9 @@
       <SelectionState runConfigName="testReadFromFirestore_returnsNullWhenDocumentDoesNotExist()">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="MainActivity">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/androidTest/java/ie/setu/mad2_assignment_one/data/ShoppingListItemListTest.kt
+++ b/app/src/androidTest/java/ie/setu/mad2_assignment_one/data/ShoppingListItemListTest.kt
@@ -1,6 +1,7 @@
 package ie.setu.mad2_assignment_one.data
 
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreSettings
 import com.google.firebase.firestore.MemoryCacheSettings
@@ -8,59 +9,77 @@ import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
-// Note that in order to run these tests, you must set up a firestore emulator on your device.
-// Info on how to do this can be found at https://cloud.google.com/firestore/docs/emulator .
-// Run the firestore emulator on 127.0.0.1:8080 .
+// To run these tests, we use Firebase CLI.
+// **SETUP INSTRUCTIONS**
+// 1. Install Firebase CLI here --> https://firebase.google.com/docs/cli#setup_update_cli .
+// 2. Log in using this command --> firebase login
+// 3. Initialise Firebase CLI using this command --> firebase init
+// 3a. Ensure you choose the correct project for firebase (evanhearne-mad2-assignment-one), or modify the project name accordingly.
+// 4. Ensure that Firebase CLI has the emulators FireStore and Authentication installed.
+// 4a. Ensure they use default ports, or modify the ports used for them below before running tests.
+// 5. Run Firebase emulator with this command --> firebase emulators:start .
+// 6. Create a new user in `Authentication` --> email -> test@auth.com , password -> abcd1234 . Modify auth below if chosen different credentials.
+// 7. Run tests with emulated/real device running.
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class ShoppingListItemListTest {
 
     private lateinit var firestore: FirebaseFirestore
+    private lateinit var firebaseAuth: FirebaseAuth
     private lateinit var testList: ShoppingListItemList
     private val testDocumentId = "testDocument" // Unique ID for the test document
 
     @Before
-    fun setUp() {
+    fun setUp() = runBlocking {
         // set up firebase store emulator
         firestore = FirebaseFirestore.getInstance()
+        firebaseAuth = FirebaseAuth.getInstance()
+        // 10.0.2.2 is Android's IP address equivalent to localhost on host machine when emulating.
+        // i.e. 10.0.2.2 (Android) <- 127.0.0.1 (Host PC // Machine we run instrument tests on)
         try {
-            // 10.0.2.2 is Android's IP address equivalent to localhost on host machine when emulating.
-            // i.e. 10.0.2.2 (Android) <- 127.0.0.1 (Host PC // Machine we run instrument tests on)
+            firebaseAuth.useEmulator("10.0.2.2", 9099)
             firestore.useEmulator("10.0.2.2", 8080)
-        } catch(e: IllegalStateException) {
-            // Catch is left empty on purpose...
-            // The try-catch block is here to allow the emulator to be set up just once.
-            // On multiple attempts it will throw an error, as the emulator is already set up.
-            // We can ignore the errors within this abyss... :0
+        } catch (e: Exception) {
+            // empty catch block to init emulators
+            print(e)
         }
-
         val settings = FirebaseFirestoreSettings.Builder()
             .setLocalCacheSettings(MemoryCacheSettings.newBuilder().build()) // Use in-memory cache
             .build()
-
         firestore.firestoreSettings = settings
+
+        firebaseAuth.signInWithEmailAndPassword("test@auth.com", "abcd1234").await()
+
         testList = ShoppingListItemList(0,
             listOf(
-                ShoppingListItem(0,ShoppingItem(0,0, "Milk", "Lovely milk", 2.30, true), 1),
-                ShoppingListItem(0,ShoppingItem(0,0, "Bread", "Today's bread, tomorrow!", 1.50, false), 1)
-            )
+                ShoppingListItem(0,ShoppingItem(0,"shoppingItem/milk.png", "Milk", "Lovely milk", 2.30,
+                    Category.GROCERIES, true, "amazingStore1"), 1),
+                ShoppingListItem(0,ShoppingItem(0,"shoppingItem/bread.png", "Bread", "Today's bread, tomorrow!", 1.50,
+                    Category.GROCERIES, false, "amazingStore2"), 1)
+            ),
+            "Don't forget to buy some cheese!"
         )
     }
 
     @After
     fun tearDown() {
-        firestore.collection("shoppingLists").document(testDocumentId).delete()
+        runBlocking {
+            firestore.collection("shoppingLists").document(testDocumentId).delete().await()
+        }
     }
 
     @Test
     fun testSaveToFirestore_savesDataCorrectly() = runTest {
+        assertNotNull(firebaseAuth.currentUser)
         ShoppingListItemList.saveToFirestore(testList, testDocumentId)
 
         val retrievedList = ShoppingListItemList.readFromFirestore(testDocumentId)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools" >
 
     <application
+        android:networkSecurityConfig="@xml/network_security_config"
         android:name=".inventory.InventoryApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -11,15 +12,13 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Mad2assignmentone"
-        tools:targetApi="31" >
+        android:theme="@style/Theme.Mad2assignmentone" >
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="${MAPS_API_KEY}" />
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.Mad2assignmentone" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <application
         android:networkSecurityConfig="@xml/network_security_config"

--- a/app/src/main/java/ie/setu/mad2_assignment_one/data/ShoppingListItemList.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/data/ShoppingListItemList.kt
@@ -24,7 +24,7 @@ data class ShoppingListItemList(
         // Read from Firestore (replace "yourDocumentId" with the actual ID)
         suspend fun readFromFirestore(documentId: String): ShoppingListItemList? {
             val currentUser = FirebaseAuth.getInstance().currentUser
-            if (currentUser != null) {
+            if (currentUser != null && (currentUser.displayName != null || currentUser.email != null)) {
                 try {
                     val documentSnapshot =
                         Firebase.firestore.collection(COLLECTION_NAME).document(documentId).get()
@@ -45,7 +45,7 @@ data class ShoppingListItemList(
         // Save to Firestore
         suspend fun saveToFirestore(shoppingList: ShoppingListItemList, documentId: String) {
             val currentUser = FirebaseAuth.getInstance().currentUser
-            if (currentUser != null) {
+            if (currentUser != null && (currentUser.displayName != null || currentUser.email != null)) {
                 try {
                     Firebase.firestore.collection(COLLECTION_NAME).document(documentId)
                         .set(shoppingList).await()

--- a/app/src/main/java/ie/setu/mad2_assignment_one/data/ShoppingListItemList.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/data/ShoppingListItemList.kt
@@ -15,7 +15,8 @@ import kotlinx.coroutines.tasks.await
 @TypeConverters(Converters::class)
 data class ShoppingListItemList(
     @PrimaryKey val id: Int = 0,
-    var list: List<ShoppingListItem> = emptyList()
+    var list: List<ShoppingListItem> = emptyList(),
+    var note: String = "",
 ) {
     companion object {
         private const val COLLECTION_NAME = "shoppingLists" // Choose a name for your collection
@@ -28,7 +29,7 @@ data class ShoppingListItemList(
                     val documentSnapshot =
                         Firebase.firestore.collection(COLLECTION_NAME).document(documentId).get()
                             .await()
-                    if (documentSnapshot.exists()) {
+                    return if (documentSnapshot.exists()) {
                         documentSnapshot.toObject(ShoppingListItemList::class.java) // Use Firestore's built-in conversion
                     } else {
                         null

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/shopping/ShoppingListScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/shopping/ShoppingListScreen.kt
@@ -3,13 +3,17 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -17,6 +21,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -53,6 +58,10 @@ fun ShoppingListScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit
     // total variable is used to display total at the end of the shopping list
     // it is calculated on the fly.
     var total: Double
+    // note string
+    val note = shoppingListViewModel.note
+    // isEdit boolean
+    var isEdit = remember { mutableStateOf(false) }
     // Top App Bar
     Column {
         Row {
@@ -209,6 +218,51 @@ fun ShoppingListScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit
                                     enabled = true,
                                 ) {
                                     Text("+", fontSize = 20.sp)
+                                }
+                            }
+                        }
+                    }
+                }
+                // Note Area
+                item {
+                    Box (modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        if (isEdit.value) {
+                            OutlinedTextField(
+                                value = note.value,
+                                onValueChange = { scope.launch { shoppingListViewModel.editNote(it) } },
+                                label = { Text("Add a note to your shopping list...") },
+                                trailingIcon = { IconButton(onClick = { isEdit.value = !isEdit.value }) {
+                                    Icon(Icons.Default.Check, contentDescription = "Confirm Edit")
+                                } })
+                        } else {
+                            Card {
+                                if (note.value == "") {
+                                    // Display text
+                                    Text("You have no notes in your shopping list! ", modifier = Modifier.padding(10.dp))
+                                    // Edit IconButton
+                                    IconButton(onClick = {isEdit.value = !isEdit.value}, modifier = Modifier.size(width = 75.dp, height=50.dp)) {
+                                        Row(
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            modifier = Modifier.padding(10.dp)
+                                        ) {
+                                            Text("Edit")
+                                            Spacer(modifier = Modifier.width(4.dp)) // Adds spacing between text and icon
+                                            Icon(Icons.Outlined.Edit, contentDescription = "Edit Icon")
+                                        }
+                                    }
+                                } else {
+                                    Text(note.value, modifier.padding(10.dp))
+                                    // Edit IconButton
+                                    IconButton(onClick = {isEdit.value = !isEdit.value}, modifier = Modifier.size(width = 75.dp, height=50.dp)) {
+                                        Row(
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            modifier = Modifier.padding(10.dp)
+                                        ) {
+                                            Text("Edit")
+                                            Spacer(modifier = Modifier.width(4.dp)) // Adds spacing between text and icon
+                                            Icon(Icons.Outlined.Edit, contentDescription = "Edit Icon")
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/shopping/ShoppingListScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/shopping/ShoppingListScreen.kt
@@ -230,24 +230,26 @@ fun ShoppingListScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit
                             OutlinedTextField(
                                 value = note.value,
                                 onValueChange = { scope.launch { shoppingListViewModel.editNote(it) } },
-                                label = { Text("Add a note to your shopping list...") },
+                                label = { Text(stringResource(R.string.add_a_note_to_your_shopping_list)) },
                                 trailingIcon = { IconButton(onClick = { isEdit.value = !isEdit.value }) {
-                                    Icon(Icons.Default.Check, contentDescription = "Confirm Edit")
+                                    Icon(Icons.Default.Check, contentDescription = stringResource(R.string.confirm_edit))
                                 } })
                         } else {
                             Card {
                                 if (note.value == "") {
                                     // Display text
-                                    Text("You have no notes in your shopping list! ", modifier = Modifier.padding(10.dp))
+                                    Text(stringResource(R.string.you_have_no_notes_in_your_shopping_list), modifier = Modifier.padding(10.dp))
                                     // Edit IconButton
                                     IconButton(onClick = {isEdit.value = !isEdit.value}, modifier = Modifier.size(width = 75.dp, height=50.dp)) {
                                         Row(
                                             verticalAlignment = Alignment.CenterVertically,
                                             modifier = Modifier.padding(10.dp)
                                         ) {
-                                            Text("Edit")
+                                            Text(stringResource(R.string.edit))
                                             Spacer(modifier = Modifier.width(4.dp)) // Adds spacing between text and icon
-                                            Icon(Icons.Outlined.Edit, contentDescription = "Edit Icon")
+                                            Icon(Icons.Outlined.Edit, contentDescription = stringResource(
+                                                R.string.edit_icon
+                                            ))
                                         }
                                     }
                                 } else {
@@ -258,9 +260,11 @@ fun ShoppingListScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit
                                             verticalAlignment = Alignment.CenterVertically,
                                             modifier = Modifier.padding(10.dp)
                                         ) {
-                                            Text("Edit")
+                                            Text(stringResource(R.string.edit))
                                             Spacer(modifier = Modifier.width(4.dp)) // Adds spacing between text and icon
-                                            Icon(Icons.Outlined.Edit, contentDescription = "Edit Icon")
+                                            Icon(Icons.Outlined.Edit, contentDescription = stringResource(
+                                                R.string.edit_icon
+                                            ))
                                         }
                                     }
                                 }

--- a/app/src/main/java/ie/setu/mad2_assignment_one/ui/user/AccountScreen.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/ui/user/AccountScreen.kt
@@ -58,7 +58,8 @@ fun AccountScreen(
             .padding(padding)
             .fillMaxSize(), verticalArrangement = Arrangement.Center) {
             var user by remember { mutableStateOf(Firebase.auth.currentUser) }
-            if (user!!.displayName != null || user!!.email != null) {
+            val currentUser = user
+            if (currentUser != null && (currentUser.displayName != null || currentUser.email != null)) {
                 // check if user logged in
                 // User Photo
                 Row(modifier = Modifier

--- a/app/src/main/java/ie/setu/mad2_assignment_one/viewmodel/ShoppingListViewModel.kt
+++ b/app/src/main/java/ie/setu/mad2_assignment_one/viewmodel/ShoppingListViewModel.kt
@@ -1,34 +1,46 @@
 package ie.setu.mad2_assignment_one.viewmodel
 
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.lifecycle.ViewModel
 import ie.setu.mad2_assignment_one.data.ShoppingListItem
 import ie.setu.mad2_assignment_one.data.ShoppingListItemList
 import ie.setu.mad2_assignment_one.data.repository.ShoppingListItemListsRepository
 import kotlinx.coroutines.flow.first
+import androidx.compose.runtime.State
 
 class ShoppingListViewModel(private val shoppingListItemListsRepository: ShoppingListItemListsRepository) : ViewModel() {
 
     private val _shoppingList = mutableStateListOf<ShoppingListItem>()
     val shoppingList: SnapshotStateList<ShoppingListItem> = _shoppingList
 
+    private val _note = mutableStateOf("")
+    val note: State<String> = _note
+
     suspend fun loadShoppingList(documentId: String = "default") {
         var savedList = ShoppingListItemList.readFromFirestore(documentId)
         if (savedList != null)
             savedList.let {
                 _shoppingList.addAll(it.list)
+                _note.value = it.note
             }
         else {
             savedList = shoppingListItemListsRepository.getShoppingListItemListStream(0).first()
             _shoppingList.addAll(savedList.list)
+            _note.value = savedList.note
         }
     }
 
     suspend fun saveShoppingList(documentId: String = "default") {
         shoppingListItemListsRepository.clear()
-        shoppingListItemListsRepository.insertShoppingListItemList(ShoppingListItemList(0, _shoppingList.toList()))
-        ShoppingListItemList.saveToFirestore(ShoppingListItemList(0, _shoppingList.toList()), documentId)
+        shoppingListItemListsRepository.insertShoppingListItemList(ShoppingListItemList(0, _shoppingList.toList(), _note.value))
+        ShoppingListItemList.saveToFirestore(ShoppingListItemList(0, _shoppingList.toList(), _note.value), documentId)
+    }
+
+    suspend fun editNote(note: String, documentId: String = "default") {
+        _note.value = note
+        saveShoppingList(documentId)
     }
 
     suspend fun addItem(item: ShoppingListItem, documentId: String = "default") {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,4 +45,9 @@
     <string name="alert_dialog_msg">Your entire list will be deleted!</string>
     <string name="modal_confirm">Confirm</string>
     <string name="modal_dismiss">Dismiss</string>
+    <string name="add_a_note_to_your_shopping_list">Add a note to your shopping list…</string>
+    <string name="confirm_edit">Confirm Edit</string>
+    <string name="edit_icon">Edit Icon</string>
+    <string name="you_have_no_notes_in_your_shopping_list">"You have no notes in your shopping list! "</string>
+    <string name="edit">Edit</string>
 </resources>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## What: 

- `ShoppingListViewModel` now has `note` field to store note and save/upload to Firestore. 
- Modified unit tests to ensure working testing and to use `note` field in testing.
- `ShoppingListScreen` now has a Notes area where a user can add a note for their shopping e.g. `check for free range eggs` . 
- Additional checks to ensure no rogue firebase uploads on anonymous auth. 

## How:

- Instrument unit test now use `Firebase CLI` to emulate Firestore and Auth . 
- `ShoppingListViewModel` now has `updateNote` function to edit note field for ROOM and Firebase. 
- `ShoppingListScreen` uses `OutlinedTextField` // `Card` with `trailingIcon` and `IconButton` to edit/confirm note.
- Checking the contents of `currentUser` to ensure it is not anonymous auth before firebase upload. 
- `clearText` over http for `10.0.2.2` address perms granted for Firebase emulation in unit tests.

## Why:

- Users may benefit from being able to add notes about the specifics of their shop. 
- Prevents accidental firebase upload/retrievals on `default` document in Firebase. 